### PR TITLE
Issue 115

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ env/
 *.log
 
 .env
+backups/

--- a/ocl/collection/views.py
+++ b/ocl/collection/views.py
@@ -534,9 +534,16 @@ class CollectionVersionExportView(ResourceAttributeChildMixin):
         return HttpResponse(status=status)
 
     def delete(self, request, *args, **kwargs):
-        if not request.user.is_staff:
-            return HttpResponseForbidden()
+        user = request.user
+        userprofile = UserProfile.objects.get(mnemonic=user.username)
         version = self.get_object()
+
+        permitted = user.is_staff or \
+                    user.is_superuser or \
+                    userprofile.is_admin_for(version.versioned_object)
+
+        if not permitted:
+            return HttpResponseForbidden()
         if version.has_export():
             key = version.get_export_key()
             if key:

--- a/ocl/integration_tests/tests/all.py
+++ b/ocl/integration_tests/tests/all.py
@@ -1726,6 +1726,73 @@ class MappingViewsTest(MappingBaseTest):
 
 
 class SourceViewTest(SourceBaseTest):
+    def test_user_is_admin(self):
+        source = Source(
+            name='source1',
+            mnemonic='source1',
+            full_name='Source One',
+            source_type='Dictionary',
+            public_access=ACCESS_TYPE_EDIT,
+            default_locale='en',
+            supported_locales=['en'],
+            website='www.source1.com',
+            description='This is the first test source',
+            is_active=True
+        )
+        kwargs = {
+            'parent_resource': self.userprofile1
+        }
+        Source.persist_new(source, self.user1, **kwargs)
+
+        source = Source(
+            name='source2',
+            mnemonic='source2',
+            full_name='Source Two',
+            source_type='Dictionary',
+            public_access=ACCESS_TYPE_EDIT,
+            default_locale='en',
+            supported_locales=['en'],
+            website='www.source1.com',
+            description='This is the second test source',
+            is_active=True
+        )
+        kwargs = {
+            'parent_resource': self.userprofile2
+        }
+        Source.persist_new(source, self.user1, **kwargs)
+
+        source = Source(
+            name='source3',
+            mnemonic='source3',
+            full_name='Source Three',
+            source_type='Dictionary',
+            public_access=ACCESS_TYPE_EDIT,
+            default_locale='en',
+            supported_locales=['en'],
+            website='www.source1.com',
+            description='This is the third test source',
+            is_active=True
+        )
+        kwargs = {
+            'parent_resource': self.org1
+        }
+        Source.persist_new(source, self.user1, **kwargs)
+
+        source1 = Source.objects.get(mnemonic='source1')
+        source2 = Source.objects.get(mnemonic='source2')
+        source3 = Source.objects.get(mnemonic='source3')
+
+        self.userprofile2.organizations.append(self.org1)
+
+        self.assertEquals(self.userprofile1.is_admin_for(source1), True)
+        self.assertEquals(self.userprofile1.is_admin_for(source2), False)
+        self.assertEquals(self.userprofile1.is_admin_for(source3), False)
+
+        self.assertEquals(self.userprofile2.is_admin_for(source1), False)
+        self.assertEquals(self.userprofile2.is_admin_for(source2), True)
+        self.assertEquals(self.userprofile2.is_admin_for(source3), True)
+
+
     def test_update_source_head(self):
         source = Source(
             name='source',

--- a/ocl/sources/views.py
+++ b/ocl/sources/views.py
@@ -438,9 +438,16 @@ class SourceVersionExportView(ResourceAttributeChildMixin):
         return HttpResponse(status=status)
 
     def delete(self, request, *args, **kwargs):
-        if not request.user.is_staff:
-            return HttpResponseForbidden()
+        user = request.user
+        userprofile = UserProfile.objects.get(mnemonic=user.username)
         version = self.get_object()
+
+        permitted = user.is_staff or \
+                    user.is_superuser or \
+                    userprofile.is_admin_for(version.versioned_object)
+
+        if not permitted:
+            return HttpResponseForbidden()
         if version.has_export():
             key = version.get_export_key()
             if key:

--- a/ocl/users/models.py
+++ b/ocl/users/models.py
@@ -1,3 +1,4 @@
+import logging
 from django.contrib import admin
 from django.contrib.auth.models import User
 from django.core.urlresolvers import reverse
@@ -10,6 +11,7 @@ from sources.models import Source
 USER_OBJECT_TYPE = 'User'
 ORG_OBJECT_TYPE = 'Organization'
 
+logger = logging.getLogger('oclapi')
 
 class UserProfile(BaseResourceModel):
     user = models.OneToOneField(User)
@@ -75,6 +77,15 @@ class UserProfile(BaseResourceModel):
     def collections_url(self):
         return reverse('collection-list', kwargs={'user': self.mnemonic})
 
+    def is_admin_for(self, concept_container):
+        if concept_container.owner_type == UserProfile.resource_type():
+            if concept_container.owner == self:
+                return True
+        else:
+            for org in self.organizations:
+                if org == concept_container.owner:
+                    return True
+        return False
 
     @property
     def num_stars(self):


### PR DESCRIPTION
This change allows repository admins to delete an export.  Previously, only staff users were allowed.

Also adds backups/ folder to .gitignore