### PR TITLE
 OpenConceptLab/ocl_issues#151: ?limit=100 is appended to some GET requests

### DIFF
--- a/integration-tests/src/org.spec.ts
+++ b/integration-tests/src/org.spec.ts
@@ -65,6 +65,15 @@ describe('Org', () => {
         expect(json).toEqual(expect.not.arrayContaining([ { id: nonPublicAdminOrg, name: nonPublicAdminOrg, url: nonPublicAdminOrgUrl } ]));
     });
 
+    test('orgs list should not be affected by query params', async () => {
+        const res = await get('orgs/?q=*');
+        const json = await res.json();
+
+        expect(json).toEqual(expect.arrayContaining([ { id: 'OCL', name: 'Open Concept Lab', url: '/orgs/OCL/' } ]));
+        expect(json).toEqual(expect.not.arrayContaining([ { id: nonPublicOrg, name: nonPublicOrg, url: nonPublicOrgUrl } ]));
+        expect(json).toEqual(expect.not.arrayContaining([ { id: nonPublicAdminOrg, name: nonPublicAdminOrg, url: nonPublicAdminOrgUrl } ]));
+    });
+
     it('should not be created by anonymous', async () => {
         const orgId = newOrgId();
         const orgUrl = orgIdToUrl(orgId);

--- a/ocl/oclapi/middlewares.py
+++ b/ocl/oclapi/middlewares.py
@@ -63,3 +63,19 @@ class RequestLogMiddleware(object):
             return "{0}\n...\n".format(msg[0:MAX_BODY_LENGTH])
         else:
             return msg
+
+
+class FixMalformedLimitParamMiddleware(object):
+    """
+    Why this was necessary: https://github.com/OpenConceptLab/ocl_issues/issues/151
+    """
+    @staticmethod
+    def process_request(request):
+        to_remove = '?limit=100'
+        if request.get_full_path()[-10:] == to_remove and request.method == 'GET':
+            query_dict_copy = request.GET.copy()
+            for key, value in query_dict_copy.iteritems():
+                query_dict_copy[key] = value.replace(to_remove, '')
+            if 'limit' not in query_dict_copy:
+                query_dict_copy['limit'] = 100
+            request.GET = query_dict_copy

--- a/ocl/oclapi/settings/common.py
+++ b/ocl/oclapi/settings/common.py
@@ -110,6 +110,7 @@ class Common(Configuration):
 
 
     MIDDLEWARE_CLASSES = (
+        'oclapi.middlewares.FixMalformedLimitParamMiddleware',
         'corsheaders.middleware.CorsMiddleware',
         'django.middleware.common.CommonMiddleware',
         'django.middleware.csrf.CsrfViewMiddleware',


### PR DESCRIPTION
Address OpenConceptLab/ocl_issues#151.

Taking a second stub at this after https://github.com/OpenConceptLab/oclapi/pull/558.
Still can't find where this limit is being appended. I have improved the implementation to only correct the param if it does exist and not merely remove it.

Kindly take a look @rkorytkowski.